### PR TITLE
v2.2

### DIFF
--- a/newsapi/build.gradle
+++ b/newsapi/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.dcendents.android-maven'
-group='com.github.dfloureiro'
+group='com.github.guneetgstar'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
@@ -13,4 +13,5 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
 }

--- a/newsapi/src/main/java/com/dfl/newsapi/NewsApiRepository.kt
+++ b/newsapi/src/main/java/com/dfl/newsapi/NewsApiRepository.kt
@@ -1,5 +1,6 @@
 package com.dfl.newsapi
 
+import com.dfl.newsapi.builder.NewsQuery
 import com.dfl.newsapi.di.Injector
 import com.dfl.newsapi.model.ArticlesDto
 import com.dfl.newsapi.model.SourcesDto
@@ -13,7 +14,7 @@ import io.reactivex.Single
 class NewsApiRepository(apiKey: String) {
 
     private val injector = Injector(apiKey)
-    private val newsApiService: NewsApiService by injector.instance()
+    private val newsApiService: NewsApiService by injector.instance<NewsApiService>()
 
     fun getSources(category: Category? = null, language: Language? = null, country: Country? = null): Single<SourcesDto> {
         return newsApiService.getSources(category?.value, language?.value, country?.value)
@@ -23,6 +24,22 @@ class NewsApiRepository(apiKey: String) {
                       to: String? = null, language: Language? = null, sortBy: SortBy? = null,
                       pageSize: Int = 20, page: Int = 1): Single<ArticlesDto> {
         return newsApiService.getEverything(q, sources, domains, from, to, language?.value, sortBy?.value, pageSize, page)
+    }
+    fun getEverything(q: NewsQuery? = null, sources: String? = null, domains: String? = null, from: String? = null,
+                      to: String? = null, language: Language? = null, sortBy: SortBy? = null,
+                      pageSize: Int = 20, page: Int = 1): Single<ArticlesDto>{
+        return newsApiService.getEverything(q.toString(), sources, domains, from, to, language?.value, sortBy?.value, pageSize, page)
+    }
+    fun getEverythingByTitle(q: String? = null, sources: String? = null, domains: String? = null, from: String? = null,
+                             to: String? = null, language: Language? = null, sortBy: SortBy? = null,
+                             pageSize: Int = 20, page: Int = 1): Single<ArticlesDto>{
+        return newsApiService.getEverythingByTitle(q, sources, domains, from, to, language?.value, sortBy?.value, pageSize, page)
+    }
+
+    fun getEverythingByTitle(q: NewsQuery? = null, sources: String? = null, domains: String? = null, from: String? = null,
+                             to: String? = null, language: Language? = null, sortBy: SortBy? = null,
+                             pageSize: Int = 20, page: Int = 1): Single<ArticlesDto>{
+        return newsApiService.getEverythingByTitle(q.toString(), sources, domains, from, to, language?.value, sortBy?.value, pageSize, page)
     }
 
     fun getTopHeadlines(category: Category? = null, country: Country? = null, q: String? = null, pageSize: Int = 20,

--- a/newsapi/src/main/java/com/dfl/newsapi/builder/NewsQuery.kt
+++ b/newsapi/src/main/java/com/dfl/newsapi/builder/NewsQuery.kt
@@ -1,0 +1,109 @@
+package com.dfl.newsapi.builder
+
+
+class NewsQuery private constructor(val query: String) {
+
+    companion object{
+        private const val SPACE = " "
+        private const val AND = "AND"
+        private const val OR = "OR"
+        private const val NOT = "NOT"
+        private const val MUST_NOT = "-"
+        private const val MUST = "+"
+        private const val EXACT_OPENING = "\""
+        private const val EXACT_CLOSING = EXACT_OPENING
+    }
+
+    class NewsQueryBuilder {
+        private val query = StringBuilder()
+
+        fun with(value: String): NewsQueryBuilder {
+            query.append(value)
+            return this
+        }
+
+        fun or(value: String): NewsQueryBuilder {
+            checkQuery()
+            query.append("$SPACE$OR$SPACE$value")
+            return this
+        }
+
+        fun orAll(list: List<String>): NewsQueryBuilder {
+            list.forEach {
+                this.or(it)
+            }
+            return this
+        }
+
+        fun and(value: String): NewsQueryBuilder {
+            checkQuery()
+            query.append("$SPACE$AND$SPACE$value")
+            return this
+        }
+
+        fun andAll(list: List<String>): NewsQueryBuilder {
+            list.forEach {
+                this.and(it)
+            }
+            return this
+        }
+
+        fun not(value: String): NewsQueryBuilder {
+            checkQuery()
+            query.append("$SPACE$NOT$SPACE$value")
+            return this
+        }
+
+        fun notAll(list: List<String>): NewsQueryBuilder {
+            list.forEach {
+                this.not(it)
+            }
+            return this
+        }
+
+        fun must(value: String): NewsQueryBuilder {
+            query.append("$SPACE$MUST$SPACE$value")
+            return this
+        }
+
+        fun mustAll(list: List<String>): NewsQueryBuilder {
+            list.forEach {
+                this.must(it)
+            }
+            return this
+        }
+
+        fun mustNot(value: String): NewsQueryBuilder {
+            query.append("$SPACE$MUST_NOT$SPACE$value")
+            return this
+        }
+
+        fun mustNotAll(list: List<String>): NewsQueryBuilder {
+            list.forEach {
+                this.mustNot(it)
+            }
+            return this
+        }
+
+        fun exact(value: String): NewsQueryBuilder {
+            query.append("$SPACE$EXACT_OPENING$value$EXACT_CLOSING")
+            return this
+        }
+
+        fun exactAll(list: List<String>): NewsQueryBuilder {
+            list.forEach {
+                this.exact(it)
+            }
+            return this
+        }
+
+        fun build(): NewsQuery = NewsQuery(this.query.toString())
+
+        private fun checkQuery() {
+            if (query.isEmpty()) throw IllegalStateException("Cannot append conditions before NewsQueryBuilder.with()")
+        }
+    }
+
+
+}
+

--- a/newsapi/src/main/java/com/dfl/newsapi/service/NewsApiService.kt
+++ b/newsapi/src/main/java/com/dfl/newsapi/service/NewsApiService.kt
@@ -16,6 +16,13 @@ internal interface NewsApiService {
                       @Query("to") to: String?, @Query("language") language: String?, @Query("sortBy") sortBy: String?,
                       @Query("pageSize") pageSize: Int?, @Query("page") page: Int?): Single<ArticlesDto>
 
+
+
+    @GET("/v2/everything")
+    fun getEverythingByTitle(@Query("qInTitle") q: String?, @Query("sources") sources: String?, @Query("domains") domains: String?, @Query("from") from: String?,
+                             @Query("to") to: String?, @Query("language") language: String?, @Query("sortBy") sortBy: String?,
+                             @Query("pageSize") pageSize: Int?, @Query("page") page: Int?): Single<ArticlesDto>
+
     @GET("/v2/top-headlines")
     fun getTopHeadlines(@Query("category") category: String?, @Query("country") country: String?,
                         @Query("sources") sources: String?, @Query("q") q: String?, @Query("pagesize") pageSize: Int?,

--- a/newsapi/src/test/java/com/dfl/newsapi/NewsApiRepositoryTest.kt
+++ b/newsapi/src/test/java/com/dfl/newsapi/NewsApiRepositoryTest.kt
@@ -1,0 +1,53 @@
+package com.dfl.newsapi
+
+import com.dfl.newsapi.builder.NewsQuery
+import com.dfl.newsapi.enums.SortBy
+import com.dfl.newsapi.model.ArticlesDto
+import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeAll
+import java.util.*
+
+internal class NewsApiRepositoryTest {
+    val TAG="News API"
+    val repo= NewsApiRepository("---YOUR_NEWS_API_KEY---")
+
+    @Test
+    fun getEverything() {
+        val single=repo.getEverything(
+                q = NewsQuery.NewsQueryBuilder().with("business").build(),
+                sortBy = SortBy.POPULARITY,
+                pageSize = 10
+        ).doOnError { println(TAG+ it.message) }
+                .doOnSuccess {  println(TAG+ it.articles.size.toString()) }
+        single.subscribe()
+        val observable=single.test()
+        observable.awaitTerminalEvent()
+        observable.assertOf {
+                    it.assertSubscribed()
+                    it.assertComplete()
+                    it.assertNoErrors()
+                }
+    }
+
+    @Test
+    fun getEverythingByTitle() {
+        val single=repo.getEverythingByTitle(
+                q = NewsQuery.NewsQueryBuilder().with("business").build(),
+                sortBy = SortBy.POPULARITY,
+                pageSize = 10
+        ).doOnError { println(TAG+ it.message) }
+                .doOnSuccess {  println(TAG+ it.articles.size.toString()) }
+        single.subscribe()
+        val observable=single.test()
+        observable.awaitTerminalEvent()
+        observable.assertOf {
+            it.assertSubscribed()
+            it.assertComplete()
+            it.assertNoErrors()
+        }
+    }
+}


### PR DESCRIPTION
Added Features in v2.2:

- Create a QueryBuilder for simplifying query creation for News API

- Use qInTitle
News API provides an endpoint "everything" to search for keywords or phrases in the article title only. This was not available in this lib until v2.2.